### PR TITLE
Fix missing ggrepel_options arguments

### DIFF
--- a/R/county.R
+++ b/R/county.R
@@ -34,12 +34,13 @@
 #' }
 #' @export
 #' @importFrom ggplot2 geom_sf
-county_choropleth = function(df, map_year = 2024, geoid.name = 'region', geoid.type = 'auto', value.name = 'value', 
+county_choropleth = function(df, map_year = 2024, geoid.name = 'region', geoid.type = 'auto', value.name = 'value',
                              num_colors = 7, color.max = NULL, color.min = NULL, na.color = 'grey', custom.colors = NULL, nbreaks = 5,
-                             county_zoom = NULL, state_zoom = NULL, projection = 'albers', 
+                             county_zoom = NULL, state_zoom = NULL, projection = 'albers',
                              border_color = 'grey15', border_thickness = 0.2,
                              background_color = 'white', gridlines = FALSE, latlon_ticks = FALSE, whitespace = TRUE,
-                             label = NULL, label_text_size = 2.25, label_text_color = 'black', label_box_color = 'white', 
+                             label = NULL, label_text_size = 2.25, label_text_color = 'black', label_box_color = 'white',
+                             ggrepel_options = NULL,
                              legend = NULL, legend_position = 'right', title = NULL, return = 'plot',
                              add_state_outline = TRUE)
 {

--- a/R/tract.R
+++ b/R/tract.R
@@ -50,12 +50,13 @@ get_tract_map = function(state_name, drop_geometry = TRUE) {
 #' @seealso \url{https://www.census.gov/data/academy/data-gems/2018/tract.html} for more information on Census Tracts
 #' @export
 #' 
-tract_choropleth = function(df, state_name, geoid.name = 'region', geoid.type = 'auto', value.name = 'value', 
+tract_choropleth = function(df, state_name, geoid.name = 'region', geoid.type = 'auto', value.name = 'value',
                             num_colors = 7, color.max = NULL, color.min = NULL, na.color = 'grey', custom.colors = NULL, nbreaks = 5,
-                            tract_zoom = NULL, county_zoom = NULL, projection = 'cartesian', 
+                            tract_zoom = NULL, county_zoom = NULL, projection = 'cartesian',
                             border_color = 'grey15', border_thickness = 0.2,
                             background_color = 'white', gridlines = FALSE, latlon_ticks = FALSE, whitespace = TRUE,
-                            label = NULL, label_text_size = 2.25, label_text_color = 'black', label_box_color = 'white', 
+                            label = NULL, label_text_size = 2.25, label_text_color = 'black', label_box_color = 'white',
+                            ggrepel_options = NULL,
                             legend = NULL, legend_position = 'right', title = NULL, return = 'plot') {
   
   tract_map = get_tract_map(state_name, drop_geometry = FALSE)

--- a/man/county_choropleth.Rd
+++ b/man/county_choropleth.Rd
@@ -29,6 +29,7 @@ county_choropleth(
   label_text_size = 2.25,
   label_text_color = "black",
   label_box_color = "white",
+  ggrepel_options = NULL,
   legend = NULL,
   legend_position = "bottom",
   title = NULL,
@@ -111,6 +112,8 @@ to create the labels and ensure that they do not overlap.}
 \item{label_text_color}{The color of the text that will appear in each label}
 
 \item{label_box_color}{The color of the box around each label}
+
+\item{ggrepel_options}{A list containing additional arguments to be passed to geom_label_repel (see ?ggplot2::geom_label_repel)}
 
 \item{legend}{A title for your legend; if NULL, value.name will be used.}
 

--- a/man/tract_choropleth.Rd
+++ b/man/tract_choropleth.Rd
@@ -29,6 +29,7 @@ tract_choropleth(
   label_text_size = 2.25,
   label_text_color = "black",
   label_box_color = "white",
+  ggrepel_options = NULL,
   legend = NULL,
   legend_position = "bottom",
   title = NULL,
@@ -112,6 +113,8 @@ to create the labels and ensure that they do not overlap.}
 \item{label_text_color}{The color of the text that will appear in each label}
 
 \item{label_box_color}{The color of the box around each label}
+
+\item{ggrepel_options}{A list containing additional arguments to be passed to geom_label_repel (see ?ggplot2::geom_label_repel)}
 
 \item{legend}{A title for your legend; if NULL, value.name will be used.}
 


### PR DESCRIPTION
## Summary
- add `ggrepel_options` parameter to `county_choropleth()` and `tract_choropleth()`
- document `ggrepel_options` in corresponding Rd files

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850702bd3588329b566f5d58689b426