### PR TITLE
Fix tract map projection and message typo

### DIFF
--- a/R/county.R
+++ b/R/county.R
@@ -68,9 +68,9 @@ county_choropleth = function(df, map_year = 2024, geoid.name = 'region', geoid.t
   
   if (!is.null(state_zoom)) {
     state_zoom_geoid = guess_geoid_type(user.regions = state_zoom, geoid.all = c('name.proper', 'name.lower', 'state.abb', 'fips.character', 'fips.numeric'),
-                                        ref.regions = choroplethr::state.regions, ref.regions.name = 'choroplethr::choroplethr::state.regions')
+                                       ref.regions = choroplethr::state.regions, ref.regions.name = 'choroplethr::state.regions')
     if (!all(state_zoom %in% choroplethr::state.regions[[state_zoom_geoid]])) {
-      stop('all elements of state_zoom must match one of the columns in choroplethr::choroplethr::state.regions')
+      stop('all elements of state_zoom must match one of the columns in choroplethr::state.regions')
     }
     state_zoom_fipsn = choroplethr::state.regions[choroplethr::state.regions[[state_zoom_geoid]] %in% state_zoom, "fips.numeric"]
     counties_in_state_zoom = ref.regions[ref.regions$state.fips.numeric %in% state_zoom_fipsn, c$geoid.type]

--- a/R/tract.R
+++ b/R/tract.R
@@ -13,7 +13,7 @@ get_tract_map = function(state_name, drop_geometry = TRUE) {
   tract.map.df = tracts(state = state_name, cb = TRUE)
   tract.map.df$tractid.numeric = as.numeric(tract.map.df$GEOID)
   tract.map.df$county.fips.numeric = as.numeric(paste0(tract.map.df$STATEFP, tract.map.df$COUNTYFP))
-  st_transform(tract.map.df, 4326)
+  tract.map.df = st_transform(tract.map.df, 4326)
   if (drop_geometry) {
     tract.map.df = as.data.frame(sf::st_drop_geometry(tract.map.df))
   }


### PR DESCRIPTION
## Summary
- transform tract map output so the new projection is stored
- fix typo in county zoom error message

## Testing
- `Rscript -e 'sessionInfo()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850702bd3588329b566f5d58689b426